### PR TITLE
Make SSID unique to each device.

### DIFF
--- a/data/js/settings.js
+++ b/data/js/settings.js
@@ -1,3 +1,0 @@
-ssid="smartpower2";
-ipaddr="192.168.4.1";
-passwd="12345678";

--- a/data/txt/settings.txt
+++ b/data/txt/settings.txt
@@ -1,2 +1,3 @@
 autorun=0
 voltage=5.00
+firstboot=1


### PR DESCRIPTION
Currently, every device shares the same SSID.  This causes issues when a new device is introduced near an existing device with the default SSID.  This patch creates a unique SSID based on the internal chip ID.  Reflashing the filesystem or forcing a reset with the on/off button causes the unique SSID to be used.